### PR TITLE
Initial Media Gallery Schemas

### DIFF
--- a/ceramic/json-ld.md
+++ b/ceramic/json-ld.md
@@ -1,0 +1,13 @@
+## What is JSON-LD?
+
+[JSON-LD](https://www.w3.org/TR/json-ld11/) is a JSON serialization format for [Linked Data](https://www.w3.org/standards/semanticweb/data). Linked Data is core to the [Semantic Web](https://en.wikipedia.org/wiki/Semantic_Web) and to the Geo Web as well.
+
+## Why Linked Data?
+
+Data on the Geo Web should be machine-readable to unlock the power of being a "web". Browsers should be able to understand content that is anchored to land in order to build user experiences on top of this data.
+
+## JSON-LD and Ceramic
+
+[Ceramic](https://www.ceramic.network) powers the content layer of the Geo Web. Most content is represented as a graph of JSON documents using the [Tile doctype](https://github.com/ceramicnetwork/CIP/blob/main/CIPs/CIP-8/CIP-8.md). All documents need a [JSON Schema](https://json-schema.org).
+
+Certain documents in the Geo Web are also represented as JSON-LD types. It is still being determined how to define these types as JSON schemas in Ceramic. For now, schemas are manually created by choosing fields from schema.org. See [MediaGalleryItem](./media-gallery-item.md) as an example.

--- a/ceramic/media-gallery-item.md
+++ b/ceramic/media-gallery-item.md
@@ -1,0 +1,44 @@
+## Simple Summary
+
+A **Media Gallery Item** is a JSON-LD representation of a [MediaObject](https://schema.org/MediaObject).
+
+### Schema
+
+See schema.org [MediaObject](https://schema.org/MediaObject) for a full list of fields. The following table lists the most common fields relevant to the Geo Web.
+
+| Property         | Description                                                                 | Value      | Required | Example                               |
+| ---------------- | --------------------------------------------------------------------------- | ---------- | -------- | ------------------------------------- |
+| `@type`          | Used to set the data type of a node or typed value.                         | string     | required | 3DModel                               |
+| `name`           | The name of the item.                                                       | string     | optional | Astronaut                             |
+| `contentUrl`     | Actual bytes of the media object, for example the image file or video file. | URI string | optional | (ipfs://, ipns://, http://, https://) |
+| `encodingFormat` | Media type typically expressed using a MIME format                          | string     | optional | model/gltf-binary                     |
+
+**Deployment:** `ceramic://kjzl6cwe1jw148ycjs9eijway3tyknr4pzuryabpw2wm8y6uokaxyd79d52i8yn`
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MediaGalleryItem",
+  "type": "object",
+  "properties": {
+    "@type": {
+      "description": "Used to set the data type of a node or typed value.",
+      "type": "string",
+      "enum": ["3DModel"]
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the item"
+    },
+    "contentUrl": {
+      "type": "string",
+      "format": "uri",
+      "description": "Actual bytes of the media object, for example the image file or video file"
+    },
+    "encodingFormat": {
+      "type": "string",
+      "description": "Media type typically expressed using a MIME format"
+    }
+  }
+}
+```

--- a/ceramic/media-gallery.md
+++ b/ceramic/media-gallery.md
@@ -1,0 +1,23 @@
+## Simple Summary
+
+A **Media Gallery** is an ordered collection of [MediaGalleryItem](./media-gallery-item.md).
+
+### Schema
+
+**Deployment:** `ceramic://kjzl6cwe1jw1483jn4rtotafswobwy0qm25q7hmgpjenf9mbrqdpfsfqiodtayv`
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MediaGallery",
+  "type": "array",
+  "items": {
+    "type": "string",
+    "maxLength": 150,
+    "$ceramic": {
+      "type": "tile",
+      "schema": "kjzl6cwe1jw148ycjs9eijway3tyknr4pzuryabpw2wm8y6uokaxyd79d52i8yn"
+    }
+  }
+}
+```

--- a/ceramic/parcel-content-root.md
+++ b/ceramic/parcel-content-root.md
@@ -4,10 +4,11 @@ The **Parcel Content Root** is the root document tied to a Geo Web Parcel.
 
 ### Schema
 
-| Property     | Description                      | Value      | Max Size | Required | Example                               |
-| ------------ | -------------------------------- | ---------- | -------- | -------- | ------------------------------------- |
-| `name`       | a name                           | string     | 150 char | optional | Mary Smith                            |
-| `webContent` | URI pointing to some web content | URI string | 150 char | optional | (ipfs://, ipns://, http://, https://) |
+| Property       | Description                                                          | Value        | Max Size | Required | Example                                                         |
+| -------------- | -------------------------------------------------------------------- | ------------ | -------- | -------- | --------------------------------------------------------------- |
+| `name`         | a name                                                               | string       | 150 char | optional | Mary Smith                                                      |
+| `webContent`   | URI pointing to some web content                                     | URI string   | 150 char | optional | (ipfs://, ipns://, http://, https://)                           |
+| `mediaGallery` | An ordered collection of [MediaGalleryItem](./media-gallery-item.md) | docId string | 150 char | optional | kjzl6cwe1jw1483jn4rtotafswobwy0qm25q7hmgpjenf9mbrqdpfsfqiodtayv |
 
 **Deployment:** `ceramic://kjzl6cwe1jw1472gwvijuu3mejkgniylrzpz54kgrzuqu8u6utnduxm7hhgtpn0`
 
@@ -25,6 +26,14 @@ The **Parcel Content Root** is the root document tied to a Geo Web Parcel.
       "type": "string",
       "format": "uri",
       "maxLength": 150
+    },
+    "mediaGallery": {
+      "type": "string",
+      "maxLength": 150,
+      "$ceramic": {
+        "type": "tile",
+        "schema": "kjzl6cwe1jw1483jn4rtotafswobwy0qm25q7hmgpjenf9mbrqdpfsfqiodtayv"
+      }
     }
   }
 }


### PR DESCRIPTION
Define initial schemas for media gallery.

More discussion and work is needed around a long-term solution for generating schemas from schema.org and publishing them. For now, schemas are being pinned on the Geo Web hosted Ceramic node.