### PR TITLE
Schemas v2

### DIFF
--- a/ceramic/schemas/media-gallery-item.json
+++ b/ceramic/schemas/media-gallery-item.json
@@ -10,7 +10,8 @@
                 "3DModel",
                 "ImageObject",
                 "VideoObject",
-                "AudioObject"
+                "AudioObject",
+                "WebObject"
             ]
         },
         "name": {
@@ -36,6 +37,20 @@
             "items": {
                 "$ref": "#"
             }
+        },
+        "metadata": {
+            "type": "object",
+            "description": "An object that contains the Metadata associated.",
+            "default": {},
+            "examples": [
+                {
+                    "scale": "1,1,1",
+                    "color": "#ff0000,#00ff00,#0000ff",
+                    "position": "1,1,1"
+                }
+            ],
+            "required": [],
+            "additionalProperties": true
         }
     }
 }

--- a/ceramic/schemas/media-gallery-item.json
+++ b/ceramic/schemas/media-gallery-item.json
@@ -38,9 +38,9 @@
                 "$ref": "#"
             }
         },
-        "metadata": {
+        "attributes": {
             "type": "object",
-            "description": "An object that contains the Metadata associated.",
+            "description": "An object that contains the Metadata attributes associated.",
             "default": {},
             "examples": [
                 {

--- a/ceramic/schemas/media-gallery-item.md
+++ b/ceramic/schemas/media-gallery-item.md
@@ -14,6 +14,7 @@ See schema.org [MediaObject](https://schema.org/MediaObject) for a full list of 
 | `contentSize`    | File size in bytes.                                                         | string               | optional | 1024                                  |
 | `encodingFormat` | Media type typically expressed using a MIME format.                         | string               | optional | model/gltf-binary                     |
 | `encoding`       | A media object that encodes this MediaObject.                               | array of MediaObject | optional | [...]                                 |
+| `metadata`       | Metadata object attributes of this MediaObject.                               | array of Metadata Object | optional | ["scale": "1,1,1", "color": "#ff0000,#00ff00,#0000ff", "position": "1,1,1"]                                 |
 
 ```json
 {
@@ -49,6 +50,13 @@ See schema.org [MediaObject](https://schema.org/MediaObject) for a full list of 
       "items": {
         "$ref": "#"
       }
+    },
+    "metadata": {
+      "type": "object",
+      "description": "An object that contains the Metadata associated.",
+      "default": {},
+      "required": [],
+      "additionalProperties": true
     }
   }
 }

--- a/ceramic/schemas/media-gallery-item.md
+++ b/ceramic/schemas/media-gallery-item.md
@@ -51,7 +51,7 @@ See schema.org [MediaObject](https://schema.org/MediaObject) for a full list of 
         "$ref": "#"
       }
     },
-    "metadata": {
+    "attributes": {
       "type": "object",
       "description": "An object that contains the Metadata associated.",
       "default": {},

--- a/ceramic/schemas/parcel-content-root.json
+++ b/ceramic/schemas/parcel-content-root.json
@@ -7,11 +7,6 @@
             "type": "string",
             "maxLength": 150
         },
-        "webContent": {
-            "type": "string",
-            "format": "uri",
-            "maxLength": 150
-        },
         "mediaGallery": {
             "type": "string",
             "maxLength": 150


### PR DESCRIPTION
- Update Schemas to accommodate metadata.
- Model metadata as array of key value pairs.
- All values are to be stringified as a proposed standard, which can be parsed by any client.

Note: WebContent can also be moved to MediaGallery, but seeking feedback.